### PR TITLE
Nuget package can be used in Visual Studio

### DIFF
--- a/.github/workflows/dotnet-buildonly.yml
+++ b/.github/workflows/dotnet-buildonly.yml
@@ -28,8 +28,8 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          6.0.x
-          8.0.x
+          6.0.1xx
+          8.0.1xx
 
     - name: Set MSBUILDDISABLENODEREUSE
       run: echo "MSBUILDDISABLENODEREUSE=1" >> $env:GITHUB_ENV


### PR DESCRIPTION
Nuget package fails with:
The analyzer assembly \dotnet\DotnetariumSCS.dll' references version '4.9.0.0' of the compiler, which is newer than the currently running version '4.8.0.0'.	

Similar issues:
https://github.com/dotnet/core/blob/main/release-notes/8.0/known-issues.md#802xx-sdk-is-not-compatible-with-178-for-some-scenarios
https://stackoverflow.com/questions/76740942/how-to-fix-the-analyzer-assembly-references-version-4-7-0-0-of-the-compiler